### PR TITLE
Enable Decoding Webhook Payloads

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
   "cSpell.words": [
+    "SCIM",
     "stytch"
   ],
   "yaml.schemas": {

--- a/lib/schemas/webhook_payload.ex
+++ b/lib/schemas/webhook_payload.ex
@@ -1,0 +1,56 @@
+defmodule Stytch.WebhookPayload do
+  @moduledoc """
+  Provides struct and type for a WebhookPayload
+  """
+
+  @type t :: %__MODULE__{
+          action: String.t(),
+          event_id: String.t(),
+          id: String.t(),
+          member: Stytch.Member.t() | nil,
+          object_type: String.t(),
+          oidc_connection: Stytch.OIDC.Connection.t() | nil,
+          organization: Stytch.Organization.t() | nil,
+          project_id: String.t(),
+          saml_connection: Stytch.SAML.Connection.t() | nil,
+          scim_group: Stytch.WebhookPayloadScimGroup.t() | nil,
+          source: String.t(),
+          timestamp: DateTime.t()
+        }
+
+  defstruct [
+    :action,
+    :event_id,
+    :id,
+    :member,
+    :object_type,
+    :oidc_connection,
+    :organization,
+    :project_id,
+    :saml_connection,
+    :scim_group,
+    :source,
+    :timestamp
+  ]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      action: {:enum, ["CREATE", "UPDATE", "DELETE"]},
+      event_id: {:string, :generic},
+      id: {:string, :generic},
+      member: {Stytch.Member, :t},
+      object_type: {:string, :generic},
+      oidc_connection: {Stytch.OIDC.Connection, :t},
+      organization: {Stytch.Organization, :t},
+      project_id: {:string, :generic},
+      saml_connection: {Stytch.SAML.Connection, :t},
+      scim_group: {Stytch.WebhookPayloadScimGroup, :t},
+      source: {:enum, ["DASHBOARD", "DIRECT", "SCIM"]},
+      timestamp: {:string, :date_time}
+    ]
+  end
+end

--- a/lib/schemas/webhook_payload_scim_group.ex
+++ b/lib/schemas/webhook_payload_scim_group.ex
@@ -1,0 +1,27 @@
+defmodule Stytch.WebhookPayloadScimGroup do
+  @moduledoc """
+  Provides struct and type for a WebhookPayloadScimGroup
+  """
+
+  @type t :: %__MODULE__{
+          connection_id: String.t() | nil,
+          group_id: String.t() | nil,
+          group_name: String.t() | nil,
+          organization_id: String.t() | nil
+        }
+
+  defstruct [:connection_id, :group_id, :group_name, :organization_id]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      connection_id: {:string, :generic},
+      group_id: {:string, :generic},
+      group_name: {:string, :generic},
+      organization_id: {:string, :generic}
+    ]
+  end
+end

--- a/lib/stytch.ex
+++ b/lib/stytch.ex
@@ -11,6 +11,6 @@ defmodule Stytch do
   """
   @spec decode_webhook(map) :: Stytch.WebhookPayload.t()
   def decode_webhook(payload) do
-    Stytch.Decoder.decode_direct(payload, Stytch.WebhookPayload)
+    Stytch.Decoder.decode_direct(payload, {Stytch.WebhookPayload, :t})
   end
 end

--- a/lib/stytch.ex
+++ b/lib/stytch.ex
@@ -1,2 +1,16 @@
 defmodule Stytch do
+  @moduledoc """
+  API Client for the Stytch B2B SaaS platform
+
+  Much of the code in this module is auto-generated from the OpenAPI specification found in
+  `vendor/stytch-openapi.yaml`. This is an unofficial, hand-crafted specification for the API.
+  """
+
+  @doc """
+  Decode a webhook payload from Stytch
+  """
+  @spec decode_webhook(map) :: Stytch.WebhookPayload.t()
+  def decode_webhook(payload) do
+    Stytch.Decoder.decode_direct(payload, Stytch.WebhookPayload)
+  end
 end

--- a/lib/stytch/decoder.ex
+++ b/lib/stytch/decoder.ex
@@ -20,6 +20,11 @@ defmodule Stytch.Decoder do
     end
   end
 
+  @spec decode_direct(term, term) :: term
+  def decode_direct(value, type) do
+    do_decode(value, type)
+  end
+
   defp do_decode(nil, _), do: nil
   defp do_decode("", :null), do: nil
   defp do_decode(value, {:string, :date}), do: Date.from_iso8601!(value)

--- a/lib/stytch/decoder.ex
+++ b/lib/stytch/decoder.ex
@@ -35,6 +35,8 @@ defmodule Stytch.Decoder do
   defp do_decode(value, [type]), do: Enum.map(value, &do_decode(&1, type))
 
   defp do_decode(%{} = value, {module, type}) do
+    Code.ensure_loaded(module)
+
     base = if function_exported?(module, :__struct__, 0), do: struct(module), else: %{}
     fields = module.__fields__(type)
 

--- a/vendor/stytch-openapi.yml
+++ b/vendor/stytch-openapi.yml
@@ -1434,6 +1434,61 @@ components:
         - webauthn_registration_id
         - domain
 
+    WebhookPayload:
+      type: object
+      properties:
+        action:
+          type: string
+          enum:
+            - CREATE
+            - UPDATE
+            - DELETE
+        event_id:
+          type: string
+        id:
+          type: string
+        object_type:
+          type: string
+        project_id:
+          type: string
+        source:
+          type: string
+          enum:
+            - DASHBOARD
+            - DIRECT
+            - SCIM
+        timestamp:
+          type: string
+          format: date-time
+        # Optional fields that may be included depending on the event
+        member:
+          $ref: "#/components/schemas/Member"
+        oidc_connection:
+          $ref: "#/components/schemas/OIDCConnection"
+        organization:
+          $ref: "#/components/schemas/Organization"
+        saml_connection:
+          $ref: "#/components/schemas/SAMLConnection"
+        scim_group:
+          type: object
+          properties:
+            connection_id:
+              type: string
+            group_id:
+              type: string
+            group_name:
+              type: string
+            organization_id:
+              type: string
+      required:
+        - action
+        - event_id
+        - id
+        - object_type
+        - project_id
+        - source
+        - timestamp
+
     X509Certificate:
       type: object
       properties:


### PR DESCRIPTION
This PR adds a helper function for doing typed decoding of webhook payloads. It also fixes an interesting issue with decoding that may cause map-type responses the first time a struct is used (due to modules not being loaded).