### PR TITLE
Derive JSON encoder protocols for all schemas

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -23,6 +23,7 @@ config :oapi_generator,
       base_module: Stytch,
       location: "lib",
       operation_subdirectory: "operations",
-      schema_subdirectory: "schemas"
+      schema_subdirectory: "schemas",
+      schema_use: Stytch.Schema
     ]
   ]

--- a/lib/schemas/active_scim_connection.ex
+++ b/lib/schemas/active_scim_connection.ex
@@ -2,6 +2,7 @@ defmodule Stytch.ActiveSCIMConnection do
   @moduledoc """
   Provides struct and type for a ActiveSCIMConnection
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           bearer_token_expires_at: DateTime.t() | nil,

--- a/lib/schemas/active_sso_connection.ex
+++ b/lib/schemas/active_sso_connection.ex
@@ -2,6 +2,7 @@ defmodule Stytch.ActiveSSOConnection do
   @moduledoc """
   Provides struct and type for a ActiveSSOConnection
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           connection_id: String.t(),

--- a/lib/schemas/authentication_factor.ex
+++ b/lib/schemas/authentication_factor.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           amazon_oauth_factor: Stytch.AuthenticationFactor.AmazonOAuth.t() | nil,

--- a/lib/schemas/authentication_factor/amazon_o_auth.ex
+++ b/lib/schemas/authentication_factor/amazon_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.AmazonOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.AmazonOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/apple_o_auth.ex
+++ b/lib/schemas/authentication_factor/apple_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.AppleOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.AppleOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/authenticator_app.ex
+++ b/lib/schemas/authentication_factor/authenticator_app.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.AuthenticatorApp do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.AuthenticatorApp
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{totp_id: String.t()}
 

--- a/lib/schemas/authentication_factor/biometric.ex
+++ b/lib/schemas/authentication_factor/biometric.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.Biometric do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.Biometric
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{biometric_registration_id: String.t()}
 

--- a/lib/schemas/authentication_factor/bitbucket_o_auth.ex
+++ b/lib/schemas/authentication_factor/bitbucket_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.BitbucketOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.BitbucketOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/coinbase_o_auth.ex
+++ b/lib/schemas/authentication_factor/coinbase_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.CoinbaseOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.CoinbaseOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/crypto_wallet.ex
+++ b/lib/schemas/authentication_factor/crypto_wallet.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.CryptoWallet do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.CryptoWallet
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           crypto_wallet_address: String.t(),

--- a/lib/schemas/authentication_factor/discord_o_auth.ex
+++ b/lib/schemas/authentication_factor/discord_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.DiscordOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.DiscordOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/email.ex
+++ b/lib/schemas/authentication_factor/email.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.Email do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.Email
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_address: String.t(), email_id: String.t()}
 

--- a/lib/schemas/authentication_factor/embeddable_magic_link.ex
+++ b/lib/schemas/authentication_factor/embeddable_magic_link.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.EmbeddableMagicLink do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.EmbeddableMagicLink
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{embedded_id: String.t()}
 

--- a/lib/schemas/authentication_factor/facebook_o_auth.ex
+++ b/lib/schemas/authentication_factor/facebook_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.FacebookOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.FacebookOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/figma_o_auth.ex
+++ b/lib/schemas/authentication_factor/figma_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.FigmaOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.FigmaOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/git_lab_o_auth.ex
+++ b/lib/schemas/authentication_factor/git_lab_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.GitLabOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.GitLabOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/github_o_auth.ex
+++ b/lib/schemas/authentication_factor/github_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.GithubOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.GithubOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/github_o_auth_exchange.ex
+++ b/lib/schemas/authentication_factor/github_o_auth_exchange.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.GithubOAuthExchange do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.GithubOAuthExchange
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t()}
 

--- a/lib/schemas/authentication_factor/google_o_auth.ex
+++ b/lib/schemas/authentication_factor/google_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.GoogleOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.GoogleOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/google_o_auth_exchange.ex
+++ b/lib/schemas/authentication_factor/google_o_auth_exchange.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.GoogleOAuthExchange do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.GoogleOAuthExchange
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t()}
 

--- a/lib/schemas/authentication_factor/hubspot_o_auth.ex
+++ b/lib/schemas/authentication_factor/hubspot_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.HubspotOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.HubspotOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/hubspot_o_auth_exchange.ex
+++ b/lib/schemas/authentication_factor/hubspot_o_auth_exchange.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.HubspotOAuthExchange do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.HubspotOAuthExchange
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t()}
 

--- a/lib/schemas/authentication_factor/impersonated.ex
+++ b/lib/schemas/authentication_factor/impersonated.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.Impersonated do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.Impersonated
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{impersonator_email_address: String.t(), impersonator_id: String.t()}
 

--- a/lib/schemas/authentication_factor/instagram_o_auth.ex
+++ b/lib/schemas/authentication_factor/instagram_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.InstagramOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.InstagramOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/linked_in_o_auth.ex
+++ b/lib/schemas/authentication_factor/linked_in_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.LinkedInOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.LinkedInOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/microsoft_o_auth.ex
+++ b/lib/schemas/authentication_factor/microsoft_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.MicrosoftOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.MicrosoftOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/o_auth_access_token_exchange.ex
+++ b/lib/schemas/authentication_factor/o_auth_access_token_exchange.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.OAuthAccessTokenExchange do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.OAuthAccessTokenExchange
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{client_id: String.t()}
 

--- a/lib/schemas/authentication_factor/oidcsso.ex
+++ b/lib/schemas/authentication_factor/oidcsso.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.OIDCSSO do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.OIDCSSO
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{external_id: String.t(), id: String.t(), provider_id: String.t()}
 

--- a/lib/schemas/authentication_factor/phone_number.ex
+++ b/lib/schemas/authentication_factor/phone_number.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.PhoneNumber do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.PhoneNumber
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{phone_id: String.t(), phone_number: String.t()}
 

--- a/lib/schemas/authentication_factor/recovery_code.ex
+++ b/lib/schemas/authentication_factor/recovery_code.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.RecoveryCode do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.RecoveryCode
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{totp_recovery_code_id: String.t()}
 

--- a/lib/schemas/authentication_factor/salesforce_o_auth.ex
+++ b/lib/schemas/authentication_factor/salesforce_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.SalesforceOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.SalesforceOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/samlsso.ex
+++ b/lib/schemas/authentication_factor/samlsso.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.SAMLSSO do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.SAMLSSO
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{external_id: String.t(), id: String.t(), provider_id: String.t()}
 

--- a/lib/schemas/authentication_factor/shopify_o_auth.ex
+++ b/lib/schemas/authentication_factor/shopify_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.ShopifyOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.ShopifyOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/slack_o_auth.ex
+++ b/lib/schemas/authentication_factor/slack_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.SlackOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.SlackOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/slack_o_auth_exchange.ex
+++ b/lib/schemas/authentication_factor/slack_o_auth_exchange.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.SlackOAuthExchange do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.SlackOAuthExchange
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t()}
 

--- a/lib/schemas/authentication_factor/snapchat_o_auth.ex
+++ b/lib/schemas/authentication_factor/snapchat_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.SnapchatOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.SnapchatOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/spotify_o_auth.ex
+++ b/lib/schemas/authentication_factor/spotify_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.SpotifyOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.SpotifyOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/steam_o_auth.ex
+++ b/lib/schemas/authentication_factor/steam_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.SteamOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.SteamOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/tik_tok_o_auth.ex
+++ b/lib/schemas/authentication_factor/tik_tok_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.TikTokOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.TikTokOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/twitch_o_auth.ex
+++ b/lib/schemas/authentication_factor/twitch_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.TwitchOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.TwitchOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/twitter_o_auth.ex
+++ b/lib/schemas/authentication_factor/twitter_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.TwitterOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.TwitterOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/authentication_factor/web_authn.ex
+++ b/lib/schemas/authentication_factor/web_authn.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.WebAuthn do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.WebAuthn
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           domain: String.t(),

--- a/lib/schemas/authentication_factor/yahoo_o_auth.ex
+++ b/lib/schemas/authentication_factor/yahoo_o_auth.ex
@@ -2,6 +2,7 @@ defmodule Stytch.AuthenticationFactor.YahooOAuth do
   @moduledoc """
   Provides struct and type for a AuthenticationFactor.YahooOAuth
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_id: String.t() | nil, id: String.t(), provider_subject: String.t()}
 

--- a/lib/schemas/connection.ex
+++ b/lib/schemas/connection.ex
@@ -2,6 +2,7 @@ defmodule Stytch.Connection do
   @moduledoc """
   Provides struct and type for a Connection
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           connection_id: String.t(),

--- a/lib/schemas/connection_implicit_role_assignment.ex
+++ b/lib/schemas/connection_implicit_role_assignment.ex
@@ -2,6 +2,7 @@ defmodule Stytch.ConnectionImplicitRoleAssignment do
   @moduledoc """
   Provides struct and type for a ConnectionImplicitRoleAssignment
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{role_id: String.t()}
 

--- a/lib/schemas/email_implicit_role_assignment.ex
+++ b/lib/schemas/email_implicit_role_assignment.ex
@@ -2,6 +2,7 @@ defmodule Stytch.EmailImplicitRoleAssignment do
   @moduledoc """
   Provides struct and type for a EmailImplicitRoleAssignment
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{domain: String.t(), role_id: String.t()}
 

--- a/lib/schemas/group_implicit_role_assignment.ex
+++ b/lib/schemas/group_implicit_role_assignment.ex
@@ -2,6 +2,7 @@ defmodule Stytch.GroupImplicitRoleAssignment do
   @moduledoc """
   Provides struct and type for a GroupImplicitRoleAssignment
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{group: String.t(), role_id: String.t()}
 

--- a/lib/schemas/jwk.ex
+++ b/lib/schemas/jwk.ex
@@ -2,6 +2,7 @@ defmodule Stytch.JWK do
   @moduledoc """
   Provides struct and type for a JWK
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           alg: String.t() | nil,

--- a/lib/schemas/member.ex
+++ b/lib/schemas/member.ex
@@ -2,6 +2,7 @@ defmodule Stytch.Member do
   @moduledoc """
   Provides struct and type for a Member
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           created_at: DateTime.t() | nil,

--- a/lib/schemas/member/role.ex
+++ b/lib/schemas/member/role.ex
@@ -2,6 +2,7 @@ defmodule Stytch.Member.Role do
   @moduledoc """
   Provides struct and type for a Member.Role
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{role_id: String.t(), sources: [Stytch.Member.RoleSource.t()]}
 

--- a/lib/schemas/member/role_source.ex
+++ b/lib/schemas/member/role_source.ex
@@ -2,6 +2,7 @@ defmodule Stytch.Member.RoleSource do
   @moduledoc """
   Provides struct and type for a Member.RoleSource
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{details: map | nil, type: String.t()}
 

--- a/lib/schemas/member/session.ex
+++ b/lib/schemas/member/session.ex
@@ -2,6 +2,7 @@ defmodule Stytch.Member.Session do
   @moduledoc """
   Provides struct and type for a Member.Session
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           authentication_factors: [Stytch.AuthenticationFactor.t()],

--- a/lib/schemas/o_auth_registration.ex
+++ b/lib/schemas/o_auth_registration.ex
@@ -2,6 +2,7 @@ defmodule Stytch.OAuthRegistration do
   @moduledoc """
   Provides struct and type for a OAuthRegistration
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           locale: String.t() | nil,

--- a/lib/schemas/oidc/connection.ex
+++ b/lib/schemas/oidc/connection.ex
@@ -2,6 +2,7 @@ defmodule Stytch.OIDC.Connection do
   @moduledoc """
   Provides struct and type for a OIDC.Connection
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           attribute_mapping: map | nil,

--- a/lib/schemas/oidc/provider_info.ex
+++ b/lib/schemas/oidc/provider_info.ex
@@ -2,6 +2,7 @@ defmodule Stytch.OIDC.ProviderInfo do
   @moduledoc """
   Provides struct and type for a OIDC.ProviderInfo
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           access_token: String.t(),

--- a/lib/schemas/organization.ex
+++ b/lib/schemas/organization.ex
@@ -2,6 +2,7 @@ defmodule Stytch.Organization do
   @moduledoc """
   Provides struct and type for a Organization
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           allowed_auth_methods: [String.t()],

--- a/lib/schemas/retired_email.ex
+++ b/lib/schemas/retired_email.ex
@@ -2,6 +2,7 @@ defmodule Stytch.RetiredEmail do
   @moduledoc """
   Provides struct and type for a RetiredEmail
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{email_address: String.t(), email_id: String.t()}
 

--- a/lib/schemas/saml/connection.ex
+++ b/lib/schemas/saml/connection.ex
@@ -2,6 +2,7 @@ defmodule Stytch.SAML.Connection do
   @moduledoc """
   Provides struct and type for a SAML.Connection
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           acs_url: String.t(),

--- a/lib/schemas/saml/connection_implicit_role_assignment.ex
+++ b/lib/schemas/saml/connection_implicit_role_assignment.ex
@@ -2,6 +2,7 @@ defmodule Stytch.SAML.ConnectionImplicitRoleAssignment do
   @moduledoc """
   Provides struct and type for a SAML.ConnectionImplicitRoleAssignment
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{role_id: String.t()}
 

--- a/lib/schemas/saml/group_implicit_role_assignment.ex
+++ b/lib/schemas/saml/group_implicit_role_assignment.ex
@@ -2,6 +2,7 @@ defmodule Stytch.SAML.GroupImplicitRoleAssignment do
   @moduledoc """
   Provides struct and type for a SAML.GroupImplicitRoleAssignment
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{group: String.t(), role_id: String.t()}
 

--- a/lib/schemas/scim_registration.ex
+++ b/lib/schemas/scim_registration.ex
@@ -2,6 +2,7 @@ defmodule Stytch.SCIMRegistration do
   @moduledoc """
   Provides struct and type for a SCIMRegistration
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           connection_id: String.t(),

--- a/lib/schemas/sso_registration.ex
+++ b/lib/schemas/sso_registration.ex
@@ -2,6 +2,7 @@ defmodule Stytch.SSORegistration do
   @moduledoc """
   Provides struct and type for a SSORegistration
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           connection_id: String.t(),

--- a/lib/schemas/x509_certificate.ex
+++ b/lib/schemas/x509_certificate.ex
@@ -2,6 +2,7 @@ defmodule Stytch.X509Certificate do
   @moduledoc """
   Provides struct and type for a X509Certificate
   """
+  use Stytch.Schema
 
   @type t :: %__MODULE__{
           certificate: String.t(),

--- a/lib/stytch/schema.ex
+++ b/lib/stytch/schema.ex
@@ -1,0 +1,10 @@
+defmodule Stytch.Schema do
+  @moduledoc false
+
+  defmacro __using__(_opts) do
+    quote do
+      @derive Jason.Encoder
+      @derive JSON.Encoder
+    end
+  end
+end


### PR DESCRIPTION
This PR ensures all schemas generated by the OpenAPI spec are JSON-encodable.