### PR TITLE
Add Helpers for Developing and Testing with JWTs

### DIFF
--- a/lib/stytch.ex
+++ b/lib/stytch.ex
@@ -36,4 +36,23 @@ defmodule Stytch do
   def verify_jwt(jwt, opts \\ []) do
     Stytch.JWKS.verify(jwt, opts)
   end
+
+  @doc """
+  Dangerously decode a signed JWT without verifying its signature
+
+  Returns the payload of the signed JWT if successful, or an error if the JWT is malformed.
+  This function should only be called on JWTs that are independently verified by the caller
+  (such as those received directly from Stytch's API). User-provided JWTs could be changed in
+  an unsigned way, and this function will not perform any verification.
+  """
+  @spec dangerously_decode_jwt(String.t()) :: {:ok, map} | {:error, Exception.t()}
+  def dangerously_decode_jwt(jwt) do
+    result =
+      JOSE.JWS.peek_payload(jwt)
+      |> JSON.decode!()
+
+    {:ok, result}
+  rescue
+    e -> {:error, %RuntimeError{message: "Failed to decode JWT payload: #{inspect(e)}"}}
+  end
 end

--- a/lib/stytch/client.ex
+++ b/lib/stytch/client.ex
@@ -71,6 +71,8 @@ defmodule Stytch.Client do
     ]
   end
 
+  defp extract_error(_unknown_format), do: []
+
   @spec put_auth_and_base_url(Req.Request.t(), {String.t(), String.t()} | nil) :: Req.Request.t()
   defp put_auth_and_base_url(req, nil) do
     opts =

--- a/lib/stytch/jwks.ex
+++ b/lib/stytch/jwks.ex
@@ -52,6 +52,8 @@ defmodule Stytch.JWKS do
         {Stytch.JWKS, auth: {"your_project_id", "your_secret"}}
       ]
 
+  Use the special value `auth: false` to disable retrieval of the JWKS entirely. This can be
+  useful in a testing environment where the default auth might be set.
   """
   use GenServer
   require Logger
@@ -196,7 +198,9 @@ defmodule Stytch.JWKS do
     put_auth(%{name: opts[:name], project_id: nil, secret: nil, jwks: []}, opts[:auth])
   end
 
-  @spec put_auth(state, {String.t(), String.t()} | nil) :: state
+  @spec put_auth(state, {String.t(), String.t()} | false | nil) :: state
+  defp put_auth(state, false), do: state
+
   defp put_auth(state, nil) do
     case Application.get_env(:stytch, :default_auth) do
       nil ->


### PR DESCRIPTION
This PR makes two changes related to development and testing of applications that use session JWTs:

1. It's now possible to affirmatively disable retrieval of the JWKS. This is helpful when `default_auth` is configured in a testing environment.
2. There's a new function for (dangerously) decoding JWTs without verification.