### PR TITLE
Add Magic Link-related Response Types

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,6 +7,7 @@ config :oapi_generator,
         AuthenticationFactor,
         Member,
         OIDC,
+        RBAC,
         SAML
       ],
       rename: [

--- a/lib/operations/magic_links.ex
+++ b/lib/operations/magic_links.ex
@@ -107,10 +107,13 @@ defmodule Stytch.MagicLinks do
     })
   end
 
+  @type send_discovery_200_json_resp :: %{request_id: String.t(), status_code: integer}
+
   @doc """
   Send discovery email
   """
-  @spec send_discovery(body :: map, opts :: keyword) :: {:ok, map} | {:error, Stytch.Error.t()}
+  @spec send_discovery(body :: map, opts :: keyword) ::
+          {:ok, Stytch.MagicLinks.send_discovery_200_json_resp()} | {:error, Stytch.Error.t()}
   def send_discovery(body, opts \\ []) do
     client = opts[:client] || @default_client
 
@@ -121,7 +124,10 @@ defmodule Stytch.MagicLinks do
       body: body,
       method: :post,
       request: [{"application/json", :map}],
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [
+        {200, {Stytch.MagicLinks, :send_discovery_200_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
   end
@@ -147,5 +153,9 @@ defmodule Stytch.MagicLinks do
       request_id: {:string, :generic},
       status_code: :integer
     ]
+  end
+
+  def __fields__(:send_discovery_200_json_resp) do
+    [request_id: {:string, :generic}, status_code: :integer]
   end
 end

--- a/lib/operations/magic_links.ex
+++ b/lib/operations/magic_links.ex
@@ -5,10 +5,29 @@ defmodule Stytch.MagicLinks do
 
   @default_client Stytch.Client
 
+  @type authenticate_200_json_resp :: %{
+          intermediate_session_token: String.t(),
+          member: Stytch.Member.t(),
+          member_authenticated: boolean,
+          member_id: String.t(),
+          member_session: Stytch.Member.Session.t() | nil,
+          method_id: String.t(),
+          mfa_required: Stytch.MFARequired.t() | nil,
+          organization: Stytch.Organization.t(),
+          organization_id: String.t(),
+          primary_required: Stytch.PrimaryRequired.t() | nil,
+          request_id: String.t(),
+          reset_sessions: boolean,
+          session_jwt: String.t(),
+          session_token: String.t(),
+          status_code: integer
+        }
+
   @doc """
   Authenticate Magic Link
   """
-  @spec authenticate(body :: map, opts :: keyword) :: {:ok, map} | {:error, Stytch.Error.t()}
+  @spec authenticate(body :: map, opts :: keyword) ::
+          {:ok, Stytch.MagicLinks.authenticate_200_json_resp()} | {:error, Stytch.Error.t()}
   def authenticate(body, opts \\ []) do
     client = opts[:client] || @default_client
 
@@ -19,7 +38,10 @@ defmodule Stytch.MagicLinks do
       body: body,
       method: :post,
       request: [{"application/json", :map}],
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [
+        {200, {Stytch.MagicLinks, :authenticate_200_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
   end
@@ -134,6 +156,26 @@ defmodule Stytch.MagicLinks do
 
   @doc false
   @spec __fields__(atom) :: keyword
+  def __fields__(:authenticate_200_json_resp) do
+    [
+      intermediate_session_token: {:string, :generic},
+      member: {Stytch.Member, :t},
+      member_authenticated: :boolean,
+      member_id: {:string, :generic},
+      member_session: {Stytch.Member.Session, :t},
+      method_id: {:string, :generic},
+      mfa_required: {Stytch.MFARequired, :t},
+      organization: {Stytch.Organization, :t},
+      organization_id: {:string, :generic},
+      primary_required: {Stytch.PrimaryRequired, :t},
+      request_id: {:string, :generic},
+      reset_sessions: :boolean,
+      session_jwt: {:string, :generic},
+      session_token: {:string, :generic},
+      status_code: :integer
+    ]
+  end
+
   def __fields__(:invite_200_json_resp) do
     [
       member: {Stytch.Member, :t},

--- a/lib/operations/magic_links.ex
+++ b/lib/operations/magic_links.ex
@@ -46,11 +46,20 @@ defmodule Stytch.MagicLinks do
     })
   end
 
+  @type authenticate_discovery_200_json_resp :: %{
+          discovered_organizations: [Stytch.DiscoveredOrganization.t()],
+          email_address: String.t(),
+          intermediate_session_token: String.t(),
+          request_id: String.t(),
+          status_code: integer
+        }
+
   @doc """
   Authenticate discovery Magic Link
   """
   @spec authenticate_discovery(body :: map, opts :: keyword) ::
-          {:ok, map} | {:error, Stytch.Error.t()}
+          {:ok, Stytch.MagicLinks.authenticate_discovery_200_json_resp()}
+          | {:error, Stytch.Error.t()}
   def authenticate_discovery(body, opts \\ []) do
     client = opts[:client] || @default_client
 
@@ -61,7 +70,10 @@ defmodule Stytch.MagicLinks do
       body: body,
       method: :post,
       request: [{"application/json", :map}],
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [
+        {200, {Stytch.MagicLinks, :authenticate_discovery_200_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
   end
@@ -172,6 +184,16 @@ defmodule Stytch.MagicLinks do
       reset_sessions: :boolean,
       session_jwt: {:string, :generic},
       session_token: {:string, :generic},
+      status_code: :integer
+    ]
+  end
+
+  def __fields__(:authenticate_discovery_200_json_resp) do
+    [
+      discovered_organizations: [{Stytch.DiscoveredOrganization, :t}],
+      email_address: {:string, :generic},
+      intermediate_session_token: {:string, :generic},
+      request_id: {:string, :generic},
       status_code: :integer
     ]
   end

--- a/lib/operations/magic_links.ex
+++ b/lib/operations/magic_links.ex
@@ -44,10 +44,19 @@ defmodule Stytch.MagicLinks do
     })
   end
 
+  @type invite_200_json_resp :: %{
+          member: Stytch.Member.t(),
+          member_id: String.t(),
+          organization: Stytch.Organization.t(),
+          request_id: String.t(),
+          status_code: integer
+        }
+
   @doc """
   Send invite email
   """
-  @spec invite(body :: map, opts :: keyword) :: {:ok, map} | {:error, Stytch.Error.t()}
+  @spec invite(body :: map, opts :: keyword) ::
+          {:ok, Stytch.MagicLinks.invite_200_json_resp()} | {:error, Stytch.Error.t()}
   def invite(body, opts \\ []) do
     client = opts[:client] || @default_client
 
@@ -58,15 +67,28 @@ defmodule Stytch.MagicLinks do
       body: body,
       method: :post,
       request: [{"application/json", :map}],
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [
+        {200, {Stytch.MagicLinks, :invite_200_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
   end
 
+  @type login_or_signup_200_json_resp :: %{
+          member: Stytch.Member.t(),
+          member_created: boolean,
+          member_id: String.t(),
+          organization: Stytch.Organization.t(),
+          request_id: String.t(),
+          status_code: integer
+        }
+
   @doc """
   Send login or signup email
   """
-  @spec login_or_signup(body :: map, opts :: keyword) :: {:ok, map} | {:error, Stytch.Error.t()}
+  @spec login_or_signup(body :: map, opts :: keyword) ::
+          {:ok, Stytch.MagicLinks.login_or_signup_200_json_resp()} | {:error, Stytch.Error.t()}
   def login_or_signup(body, opts \\ []) do
     client = opts[:client] || @default_client
 
@@ -77,7 +99,10 @@ defmodule Stytch.MagicLinks do
       body: body,
       method: :post,
       request: [{"application/json", :map}],
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [
+        {200, {Stytch.MagicLinks, :login_or_signup_200_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
   end
@@ -99,5 +124,28 @@ defmodule Stytch.MagicLinks do
       response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
       opts: opts
     })
+  end
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(:invite_200_json_resp) do
+    [
+      member: {Stytch.Member, :t},
+      member_id: {:string, :generic},
+      organization: {Stytch.Organization, :t},
+      request_id: {:string, :generic},
+      status_code: :integer
+    ]
+  end
+
+  def __fields__(:login_or_signup_200_json_resp) do
+    [
+      member: {Stytch.Member, :t},
+      member_created: :boolean,
+      member_id: {:string, :generic},
+      organization: {Stytch.Organization, :t},
+      request_id: {:string, :generic},
+      status_code: :integer
+    ]
   end
 end

--- a/lib/operations/o_auth.ex
+++ b/lib/operations/o_auth.ex
@@ -92,6 +92,45 @@ defmodule Stytch.OAuth do
     })
   end
 
+  @type login_github_307_json_resp :: %{
+          redirect_url: String.t() | nil,
+          request_id: String.t() | nil,
+          status_code: integer | nil
+        }
+
+  @doc """
+  Login with GitHub
+
+  ## Options
+
+    * `public_token`
+
+  """
+  @spec login_github(opts :: keyword) :: :ok | {:error, Stytch.Error.t()}
+  def login_github(opts \\ []) do
+    client = opts[:client] || @default_client
+    query = Keyword.take(opts, [:public_token])
+
+    client.request(%{
+      args: [],
+      call: {Stytch.OAuth, :login_github},
+      url: "/v1/b2b/public/oauth/github/start",
+      method: :get,
+      query: query,
+      response: [
+        {307, {Stytch.OAuth, :login_github_307_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
+      opts: opts
+    })
+  end
+
+  @type login_google_302_json_resp :: %{
+          redirect_url: String.t() | nil,
+          request_id: String.t() | nil,
+          status_code: integer | nil
+        }
+
   @doc """
   Login with Google
 
@@ -100,7 +139,7 @@ defmodule Stytch.OAuth do
     * `public_token`
 
   """
-  @spec login_google(opts :: keyword) :: {:ok, map} | {:error, Stytch.Error.t()}
+  @spec login_google(opts :: keyword) :: :ok | {:error, Stytch.Error.t()}
   def login_google(opts \\ []) do
     client = opts[:client] || @default_client
     query = Keyword.take(opts, [:public_token])
@@ -111,10 +150,52 @@ defmodule Stytch.OAuth do
       url: "/v1/b2b/public/oauth/google/start",
       method: :get,
       query: query,
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [
+        {302, {Stytch.OAuth, :login_google_302_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
   end
+
+  @type login_hubspot_307_json_resp :: %{
+          redirect_url: String.t() | nil,
+          request_id: String.t() | nil,
+          status_code: integer | nil
+        }
+
+  @doc """
+  Login with HubSpot
+
+  ## Options
+
+    * `public_token`
+
+  """
+  @spec login_hubspot(opts :: keyword) :: :ok | {:error, Stytch.Error.t()}
+  def login_hubspot(opts \\ []) do
+    client = opts[:client] || @default_client
+    query = Keyword.take(opts, [:public_token])
+
+    client.request(%{
+      args: [],
+      call: {Stytch.OAuth, :login_hubspot},
+      url: "/v1/b2b/public/oauth/hubspot/start",
+      method: :get,
+      query: query,
+      response: [
+        {307, {Stytch.OAuth, :login_hubspot_307_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
+      opts: opts
+    })
+  end
+
+  @type login_microsoft_302_json_resp :: %{
+          redirect_url: String.t() | nil,
+          request_id: String.t() | nil,
+          status_code: integer | nil
+        }
 
   @doc """
   Login with Microsoft
@@ -124,7 +205,7 @@ defmodule Stytch.OAuth do
     * `public_token`
 
   """
-  @spec login_microsoft(opts :: keyword) :: {:ok, map} | {:error, Stytch.Error.t()}
+  @spec login_microsoft(opts :: keyword) :: :ok | {:error, Stytch.Error.t()}
   def login_microsoft(opts \\ []) do
     client = opts[:client] || @default_client
     query = Keyword.take(opts, [:public_token])
@@ -135,8 +216,66 @@ defmodule Stytch.OAuth do
       url: "/v1/b2b/public/oauth/microsoft/start",
       method: :get,
       query: query,
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [
+        {302, {Stytch.OAuth, :login_microsoft_302_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
+  end
+
+  @type login_slack_307_json_resp :: %{
+          redirect_url: String.t() | nil,
+          request_id: String.t() | nil,
+          status_code: integer | nil
+        }
+
+  @doc """
+  Login with Slack
+
+  ## Options
+
+    * `public_token`
+
+  """
+  @spec login_slack(opts :: keyword) :: :ok | {:error, Stytch.Error.t()}
+  def login_slack(opts \\ []) do
+    client = opts[:client] || @default_client
+    query = Keyword.take(opts, [:public_token])
+
+    client.request(%{
+      args: [],
+      call: {Stytch.OAuth, :login_slack},
+      url: "/v1/b2b/public/oauth/slack/start",
+      method: :get,
+      query: query,
+      response: [
+        {307, {Stytch.OAuth, :login_slack_307_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
+      opts: opts
+    })
+  end
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(:login_github_307_json_resp) do
+    [redirect_url: {:string, :generic}, request_id: {:string, :generic}, status_code: :integer]
+  end
+
+  def __fields__(:login_google_302_json_resp) do
+    [redirect_url: {:string, :generic}, request_id: {:string, :generic}, status_code: :integer]
+  end
+
+  def __fields__(:login_hubspot_307_json_resp) do
+    [redirect_url: {:string, :generic}, request_id: {:string, :generic}, status_code: :integer]
+  end
+
+  def __fields__(:login_microsoft_302_json_resp) do
+    [redirect_url: {:string, :generic}, request_id: {:string, :generic}, status_code: :integer]
+  end
+
+  def __fields__(:login_slack_307_json_resp) do
+    [redirect_url: {:string, :generic}, request_id: {:string, :generic}, status_code: :integer]
   end
 end

--- a/lib/operations/o_auth.ex
+++ b/lib/operations/o_auth.ex
@@ -76,6 +76,45 @@ defmodule Stytch.OAuth do
     })
   end
 
+  @type discovery_github_307_json_resp :: %{
+          redirect_url: String.t() | nil,
+          request_id: String.t() | nil,
+          status_code: integer | nil
+        }
+
+  @doc """
+  Use GitHub for discovery
+
+  ## Options
+
+    * `public_token`
+
+  """
+  @spec discovery_github(opts :: keyword) :: :ok | {:error, Stytch.Error.t()}
+  def discovery_github(opts \\ []) do
+    client = opts[:client] || @default_client
+    query = Keyword.take(opts, [:public_token])
+
+    client.request(%{
+      args: [],
+      call: {Stytch.OAuth, :discovery_github},
+      url: "/v1/b2b/public/oauth/github/discovery/start",
+      method: :get,
+      query: query,
+      response: [
+        {307, {Stytch.OAuth, :discovery_github_307_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
+      opts: opts
+    })
+  end
+
+  @type discovery_google_302_json_resp :: %{
+          redirect_url: String.t() | nil,
+          request_id: String.t() | nil,
+          status_code: integer | nil
+        }
+
   @doc """
   Use Google for discovery
 
@@ -84,7 +123,7 @@ defmodule Stytch.OAuth do
     * `public_token`
 
   """
-  @spec discovery_google(opts :: keyword) :: {:ok, map} | {:error, Stytch.Error.t()}
+  @spec discovery_google(opts :: keyword) :: :ok | {:error, Stytch.Error.t()}
   def discovery_google(opts \\ []) do
     client = opts[:client] || @default_client
     query = Keyword.take(opts, [:public_token])
@@ -95,10 +134,52 @@ defmodule Stytch.OAuth do
       url: "/v1/b2b/public/oauth/google/discovery/start",
       method: :get,
       query: query,
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [
+        {302, {Stytch.OAuth, :discovery_google_302_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
   end
+
+  @type discovery_hubspot_307_json_resp :: %{
+          redirect_url: String.t() | nil,
+          request_id: String.t() | nil,
+          status_code: integer | nil
+        }
+
+  @doc """
+  Use HubSpot for discovery
+
+  ## Options
+
+    * `public_token`
+
+  """
+  @spec discovery_hubspot(opts :: keyword) :: :ok | {:error, Stytch.Error.t()}
+  def discovery_hubspot(opts \\ []) do
+    client = opts[:client] || @default_client
+    query = Keyword.take(opts, [:public_token])
+
+    client.request(%{
+      args: [],
+      call: {Stytch.OAuth, :discovery_hubspot},
+      url: "/v1/b2b/public/oauth/hubspot/discovery/start",
+      method: :get,
+      query: query,
+      response: [
+        {307, {Stytch.OAuth, :discovery_hubspot_307_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
+      opts: opts
+    })
+  end
+
+  @type discovery_microsoft_302_json_resp :: %{
+          redirect_url: String.t() | nil,
+          request_id: String.t() | nil,
+          status_code: integer | nil
+        }
 
   @doc """
   Use Microsoft for discovery
@@ -108,7 +189,7 @@ defmodule Stytch.OAuth do
     * `public_token`
 
   """
-  @spec discovery_microsoft(opts :: keyword) :: {:ok, map} | {:error, Stytch.Error.t()}
+  @spec discovery_microsoft(opts :: keyword) :: :ok | {:error, Stytch.Error.t()}
   def discovery_microsoft(opts \\ []) do
     client = opts[:client] || @default_client
     query = Keyword.take(opts, [:public_token])
@@ -119,7 +200,40 @@ defmodule Stytch.OAuth do
       url: "/v1/b2b/public/oauth/microsoft/discovery/start",
       method: :get,
       query: query,
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [{302, {Stytch.OAuth, :discovery_microsoft_302_json_resp}}],
+      opts: opts
+    })
+  end
+
+  @type discovery_slack_307_json_resp :: %{
+          redirect_url: String.t() | nil,
+          request_id: String.t() | nil,
+          status_code: integer | nil
+        }
+
+  @doc """
+  Use Slack for discovery
+
+  ## Options
+
+    * `public_token`
+
+  """
+  @spec discovery_slack(opts :: keyword) :: :ok | {:error, Stytch.Error.t()}
+  def discovery_slack(opts \\ []) do
+    client = opts[:client] || @default_client
+    query = Keyword.take(opts, [:public_token])
+
+    client.request(%{
+      args: [],
+      call: {Stytch.OAuth, :discovery_slack},
+      url: "/v1/b2b/public/oauth/slack/discovery/start",
+      method: :get,
+      query: query,
+      response: [
+        {307, {Stytch.OAuth, :discovery_slack_307_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
   end
@@ -321,6 +435,26 @@ defmodule Stytch.OAuth do
       refresh_token: {:string, :generic},
       scopes: [string: :generic]
     ]
+  end
+
+  def __fields__(:discovery_github_307_json_resp) do
+    [redirect_url: {:string, :generic}, request_id: {:string, :generic}, status_code: :integer]
+  end
+
+  def __fields__(:discovery_google_302_json_resp) do
+    [redirect_url: {:string, :generic}, request_id: {:string, :generic}, status_code: :integer]
+  end
+
+  def __fields__(:discovery_hubspot_307_json_resp) do
+    [redirect_url: {:string, :generic}, request_id: {:string, :generic}, status_code: :integer]
+  end
+
+  def __fields__(:discovery_microsoft_302_json_resp) do
+    [redirect_url: {:string, :generic}, request_id: {:string, :generic}, status_code: :integer]
+  end
+
+  def __fields__(:discovery_slack_307_json_resp) do
+    [redirect_url: {:string, :generic}, request_id: {:string, :generic}, status_code: :integer]
   end
 
   def __fields__(:login_github_307_json_resp) do

--- a/lib/operations/o_auth.ex
+++ b/lib/operations/o_auth.ex
@@ -56,11 +56,23 @@ defmodule Stytch.OAuth do
     })
   end
 
+  @type authenticate_discovery_200_json_resp :: %{
+          discovered_organizations: [Stytch.DiscoveredOrganization.t()],
+          email_address: String.t(),
+          full_name: String.t(),
+          intermediate_session_token: String.t(),
+          provider_tenant_id: String.t(),
+          provider_tenant_ids: [String.t()],
+          provider_type: String.t(),
+          request_id: String.t(),
+          status_code: integer
+        }
+
   @doc """
   Authenticate discovery OAuth
   """
   @spec authenticate_discovery(body :: map, opts :: keyword) ::
-          {:ok, map} | {:error, Stytch.Error.t()}
+          {:ok, Stytch.OAuth.authenticate_discovery_200_json_resp()} | {:error, Stytch.Error.t()}
   def authenticate_discovery(body, opts \\ []) do
     client = opts[:client] || @default_client
 
@@ -71,7 +83,10 @@ defmodule Stytch.OAuth do
       body: body,
       method: :post,
       request: [{"application/json", :map}],
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [
+        {200, {Stytch.OAuth, :authenticate_discovery_200_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
   end
@@ -434,6 +449,20 @@ defmodule Stytch.OAuth do
       id_token: {:string, :generic},
       refresh_token: {:string, :generic},
       scopes: [string: :generic]
+    ]
+  end
+
+  def __fields__(:authenticate_discovery_200_json_resp) do
+    [
+      discovered_organizations: [{Stytch.DiscoveredOrganization, :t}],
+      email_address: {:string, :generic},
+      full_name: {:string, :generic},
+      intermediate_session_token: {:string, :generic},
+      provider_tenant_id: {:string, :generic},
+      provider_tenant_ids: [string: :generic],
+      provider_type: {:string, :generic},
+      request_id: {:string, :generic},
+      status_code: :integer
     ]
   end
 

--- a/lib/operations/o_auth.ex
+++ b/lib/operations/o_auth.ex
@@ -5,10 +5,39 @@ defmodule Stytch.OAuth do
 
   @default_client Stytch.Client
 
+  @type authenticate_200_json_resp :: %{
+          intermediate_session_token: String.t(),
+          member: Stytch.Member.t(),
+          member_authenticated: boolean,
+          member_id: String.t(),
+          member_session: Stytch.Member.Session.t() | nil,
+          mfa_required: Stytch.MFARequired.t() | nil,
+          organization: Stytch.Organization.t(),
+          organization_id: String.t(),
+          primary_required: Stytch.PrimaryRequired.t() | nil,
+          provider_subject: String.t(),
+          provider_type: String.t(),
+          provider_values: Stytch.OAuth.authenticate_200_json_resp_provider_values() | nil,
+          request_id: String.t(),
+          reset_sessions: boolean,
+          session_jwt: String.t(),
+          session_token: String.t(),
+          status_code: integer
+        }
+
+  @type authenticate_200_json_resp_provider_values :: %{
+          access_token: String.t() | nil,
+          expires_at: String.t() | nil,
+          id_token: String.t() | nil,
+          refresh_token: String.t() | nil,
+          scopes: [String.t()] | nil
+        }
+
   @doc """
   Authenticate OAuth
   """
-  @spec authenticate(body :: map, opts :: keyword) :: {:ok, map} | {:error, Stytch.Error.t()}
+  @spec authenticate(body :: map, opts :: keyword) ::
+          {:ok, Stytch.OAuth.authenticate_200_json_resp()} | {:error, Stytch.Error.t()}
   def authenticate(body, opts \\ []) do
     client = opts[:client] || @default_client
 
@@ -19,7 +48,10 @@ defmodule Stytch.OAuth do
       body: body,
       method: :post,
       request: [{"application/json", :map}],
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [
+        {200, {Stytch.OAuth, :authenticate_200_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
   end
@@ -259,6 +291,38 @@ defmodule Stytch.OAuth do
 
   @doc false
   @spec __fields__(atom) :: keyword
+  def __fields__(:authenticate_200_json_resp) do
+    [
+      intermediate_session_token: {:string, :generic},
+      member: {Stytch.Member, :t},
+      member_authenticated: :boolean,
+      member_id: {:string, :generic},
+      member_session: {Stytch.Member.Session, :t},
+      mfa_required: {Stytch.MFARequired, :t},
+      organization: {Stytch.Organization, :t},
+      organization_id: {:string, :generic},
+      primary_required: {Stytch.PrimaryRequired, :t},
+      provider_subject: {:string, :generic},
+      provider_type: {:string, :generic},
+      provider_values: {Stytch.OAuth, :authenticate_200_json_resp_provider_values},
+      request_id: {:string, :generic},
+      reset_sessions: :boolean,
+      session_jwt: {:string, :generic},
+      session_token: {:string, :generic},
+      status_code: :integer
+    ]
+  end
+
+  def __fields__(:authenticate_200_json_resp_provider_values) do
+    [
+      access_token: {:string, :generic},
+      expires_at: {:string, :generic},
+      id_token: {:string, :generic},
+      refresh_token: {:string, :generic},
+      scopes: [string: :generic]
+    ]
+  end
+
   def __fields__(:login_github_307_json_resp) do
     [redirect_url: {:string, :generic}, request_id: {:string, :generic}, status_code: :integer]
   end

--- a/lib/operations/rbac.ex
+++ b/lib/operations/rbac.ex
@@ -5,10 +5,17 @@ defmodule Stytch.RBAC do
 
   @default_client Stytch.Client
 
+  @type get_policy_200_json_resp :: %{
+          policy: Stytch.RBAC.Policy.t() | nil,
+          request_id: String.t(),
+          status_code: integer
+        }
+
   @doc """
   Get RBAC Policy
   """
-  @spec get_policy(opts :: keyword) :: {:ok, map} | {:error, Stytch.Error.t()}
+  @spec get_policy(opts :: keyword) ::
+          {:ok, Stytch.RBAC.get_policy_200_json_resp()} | {:error, Stytch.Error.t()}
   def get_policy(opts \\ []) do
     client = opts[:client] || @default_client
 
@@ -17,8 +24,17 @@ defmodule Stytch.RBAC do
       call: {Stytch.RBAC, :get_policy},
       url: "/v1/b2b/rbac/policy",
       method: :get,
-      response: [{200, :map}, default: {Stytch.ErrorResponse, :t}],
+      response: [
+        {200, {Stytch.RBAC, :get_policy_200_json_resp}},
+        default: {Stytch.ErrorResponse, :t}
+      ],
       opts: opts
     })
+  end
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(:get_policy_200_json_resp) do
+    [policy: {Stytch.RBAC.Policy, :t}, request_id: {:string, :generic}, status_code: :integer]
   end
 end

--- a/lib/schemas/discovered_organization.ex
+++ b/lib/schemas/discovered_organization.ex
@@ -1,0 +1,30 @@
+defmodule Stytch.DiscoveredOrganization do
+  @moduledoc """
+  Provides struct and type for a DiscoveredOrganization
+  """
+  use Stytch.Schema
+
+  @type t :: %__MODULE__{
+          member_authenticated: boolean,
+          membership: Stytch.Membership.t() | nil,
+          mfa_required: Stytch.MFARequired.t() | nil,
+          organization: Stytch.Organization.t() | nil,
+          primary_required: Stytch.PrimaryRequired.t() | nil
+        }
+
+  defstruct [:member_authenticated, :membership, :mfa_required, :organization, :primary_required]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      member_authenticated: :boolean,
+      membership: {Stytch.Membership, :t},
+      mfa_required: {Stytch.MFARequired, :t},
+      organization: {Stytch.Organization, :t},
+      primary_required: {Stytch.PrimaryRequired, :t}
+    ]
+  end
+end

--- a/lib/schemas/member/options.ex
+++ b/lib/schemas/member/options.ex
@@ -1,0 +1,18 @@
+defmodule Stytch.Member.Options do
+  @moduledoc """
+  Provides struct and type for a Member.Options
+  """
+  use Stytch.Schema
+
+  @type t :: %__MODULE__{mfa_phone_number: String.t(), totp_registration_id: String.t()}
+
+  defstruct [:mfa_phone_number, :totp_registration_id]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [mfa_phone_number: {:string, :generic}, totp_registration_id: {:string, :generic}]
+  end
+end

--- a/lib/schemas/membership.ex
+++ b/lib/schemas/membership.ex
@@ -1,0 +1,18 @@
+defmodule Stytch.Membership do
+  @moduledoc """
+  Provides struct and type for a Membership
+  """
+  use Stytch.Schema
+
+  @type t :: %__MODULE__{details: map | nil, member: Stytch.Member.t() | nil, type: String.t()}
+
+  defstruct [:details, :member, :type]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [details: :map, member: {Stytch.Member, :t}, type: {:string, :generic}]
+  end
+end

--- a/lib/schemas/mfa_required.ex
+++ b/lib/schemas/mfa_required.ex
@@ -1,0 +1,21 @@
+defmodule Stytch.MFARequired do
+  @moduledoc """
+  Provides struct and type for a MFARequired
+  """
+  use Stytch.Schema
+
+  @type t :: %__MODULE__{
+          member_options: Stytch.Member.Options.t() | nil,
+          secondary_auth_initiated: String.t() | nil
+        }
+
+  defstruct [:member_options, :secondary_auth_initiated]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [member_options: {Stytch.Member.Options, :t}, secondary_auth_initiated: {:string, :generic}]
+  end
+end

--- a/lib/schemas/primary_required.ex
+++ b/lib/schemas/primary_required.ex
@@ -1,0 +1,18 @@
+defmodule Stytch.PrimaryRequired do
+  @moduledoc """
+  Provides struct and type for a PrimaryRequired
+  """
+  use Stytch.Schema
+
+  @type t :: %__MODULE__{allowed_auth_methods: [String.t()]}
+
+  defstruct [:allowed_auth_methods]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [allowed_auth_methods: [string: :generic]]
+  end
+end

--- a/lib/schemas/rbac/policy.ex
+++ b/lib/schemas/rbac/policy.ex
@@ -1,0 +1,26 @@
+defmodule Stytch.RBAC.Policy do
+  @moduledoc """
+  Provides struct and type for a RBAC.Policy
+  """
+  use Stytch.Schema
+
+  @type t :: %__MODULE__{
+          resources: [Stytch.RBAC.PolicyResource.t()],
+          roles: [Stytch.RBAC.PolicyRole.t()],
+          scopes: [Stytch.RBAC.PolicyScope.t()]
+        }
+
+  defstruct [:resources, :roles, :scopes]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      resources: [{Stytch.RBAC.PolicyResource, :t}],
+      roles: [{Stytch.RBAC.PolicyRole, :t}],
+      scopes: [{Stytch.RBAC.PolicyScope, :t}]
+    ]
+  end
+end

--- a/lib/schemas/rbac/policy_resource.ex
+++ b/lib/schemas/rbac/policy_resource.ex
@@ -1,0 +1,22 @@
+defmodule Stytch.RBAC.PolicyResource do
+  @moduledoc """
+  Provides struct and type for a RBAC.PolicyResource
+  """
+  use Stytch.Schema
+
+  @type t :: %__MODULE__{actions: [String.t()], description: String.t(), resource_id: String.t()}
+
+  defstruct [:actions, :description, :resource_id]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      actions: [string: :generic],
+      description: {:string, :generic},
+      resource_id: {:string, :generic}
+    ]
+  end
+end

--- a/lib/schemas/rbac/policy_role.ex
+++ b/lib/schemas/rbac/policy_role.ex
@@ -1,0 +1,26 @@
+defmodule Stytch.RBAC.PolicyRole do
+  @moduledoc """
+  Provides struct and type for a RBAC.PolicyRole
+  """
+  use Stytch.Schema
+
+  @type t :: %__MODULE__{
+          description: String.t(),
+          permissions: [Stytch.RBAC.PolicyRolePermission.t()],
+          role_id: String.t()
+        }
+
+  defstruct [:description, :permissions, :role_id]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      description: {:string, :generic},
+      permissions: [{Stytch.RBAC.PolicyRolePermission, :t}],
+      role_id: {:string, :generic}
+    ]
+  end
+end

--- a/lib/schemas/rbac/policy_role_permission.ex
+++ b/lib/schemas/rbac/policy_role_permission.ex
@@ -1,0 +1,18 @@
+defmodule Stytch.RBAC.PolicyRolePermission do
+  @moduledoc """
+  Provides struct and type for a RBAC.PolicyRolePermission
+  """
+  use Stytch.Schema
+
+  @type t :: %__MODULE__{actions: [String.t()], resource_id: String.t()}
+
+  defstruct [:actions, :resource_id]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [actions: [string: :generic], resource_id: {:string, :generic}]
+  end
+end

--- a/lib/schemas/rbac/policy_scope.ex
+++ b/lib/schemas/rbac/policy_scope.ex
@@ -1,0 +1,26 @@
+defmodule Stytch.RBAC.PolicyScope do
+  @moduledoc """
+  Provides struct and type for a RBAC.PolicyScope
+  """
+  use Stytch.Schema
+
+  @type t :: %__MODULE__{
+          description: String.t(),
+          permissions: [Stytch.RBAC.PolicyScopePermission.t()],
+          scope: String.t()
+        }
+
+  defstruct [:description, :permissions, :scope]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [
+      description: {:string, :generic},
+      permissions: [{Stytch.RBAC.PolicyScopePermission, :t}],
+      scope: {:string, :generic}
+    ]
+  end
+end

--- a/lib/schemas/rbac/policy_scope_permission.ex
+++ b/lib/schemas/rbac/policy_scope_permission.ex
@@ -1,0 +1,18 @@
+defmodule Stytch.RBAC.PolicyScopePermission do
+  @moduledoc """
+  Provides struct and type for a RBAC.PolicyScopePermission
+  """
+  use Stytch.Schema
+
+  @type t :: %__MODULE__{actions: [String.t()], resource_id: String.t()}
+
+  defstruct [:actions, :resource_id]
+
+  @doc false
+  @spec __fields__(atom) :: keyword
+  def __fields__(type \\ :t)
+
+  def __fields__(:t) do
+    [actions: [string: :generic], resource_id: {:string, :generic}]
+  end
+end

--- a/vendor/stytch-openapi.yml
+++ b/vendor/stytch-openapi.yml
@@ -2530,6 +2530,20 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                required:
+                  - request_id
+                  - status_code
         default:
           description: Error response
           content:

--- a/vendor/stytch-openapi.yml
+++ b/vendor/stytch-openapi.yml
@@ -3025,12 +3025,26 @@ paths:
             type: string
           example: "{{PUBLIC_TOKEN}}"
       responses:
-        "200":
+        "302":
           description: Successful response
           content:
             application/json:
               schema:
                 type: object
+                properties:
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  redirect_url:
+                    type: string
+                    description: The url to redirect to. This should be done automatically by the browser.
         default:
           description: Error response
           content:
@@ -3052,12 +3066,149 @@ paths:
             type: string
           example: "{{PUBLIC_TOKEN}}"
       responses:
-        "200":
+        "302":
           description: Successful response
           content:
             application/json:
               schema:
                 type: object
+                properties:
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  redirect_url:
+                    type: string
+                    description: The url to redirect to. This should be done automatically by the browser.
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /v1/b2b/public/oauth/hubspot/start:
+    get:
+      operationId: oauth/login_hubspot
+      tags:
+        - oauth
+      summary: Login with HubSpot
+      security:
+        - noauthAuth: []
+      parameters:
+        - name: public_token
+          in: query
+          schema:
+            type: string
+          example: "{{PUBLIC_TOKEN}}"
+      responses:
+        "307":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  redirect_url:
+                    type: string
+                    description: The url to redirect to. This should be done automatically by the browser.
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /v1/b2b/public/oauth/slack/start:
+    get:
+      operationId: oauth/login_slack
+      tags:
+        - oauth
+      summary: Login with Slack
+      security:
+        - noauthAuth: []
+      parameters:
+        - name: public_token
+          in: query
+          schema:
+            type: string
+          example: "{{PUBLIC_TOKEN}}"
+      responses:
+        "307":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  redirect_url:
+                    type: string
+                    description: The url to redirect to. This should be done automatically by the browser.
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /v1/b2b/public/oauth/github/start:
+    get:
+      operationId: oauth/login_github
+      tags:
+        - oauth
+      summary: Login with GitHub
+      security:
+        - noauthAuth: []
+      parameters:
+        - name: public_token
+          in: query
+          schema:
+            type: string
+          example: "{{PUBLIC_TOKEN}}"
+      responses:
+        "307":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  redirect_url:
+                    type: string
+                    description: The url to redirect to. This should be done automatically by the browser.
         default:
           description: Error response
           content:

--- a/vendor/stytch-openapi.yml
+++ b/vendor/stytch-openapi.yml
@@ -656,6 +656,19 @@ components:
         - default_mfa_method
         - roles
 
+    MemberOptions:
+      type: object
+      properties:
+        mfa_phone_number:
+          type: string
+          description: The Member's MFA phone number.
+        totp_registration_id:
+          type: string
+          description: The Member's MFA TOTP registration ID.
+      required:
+        - mfa_phone_number
+        - totp_registration_id
+
     MemberRole:
       type: object
       properties:
@@ -738,6 +751,20 @@ components:
         - authentication_factors
         - organization_id
         - roles
+
+    MfaRequired:
+      type: object
+      properties:
+        member_options:
+          $ref: "#/components/schemas/MemberOptions"
+          description: Information about the Member's options for completing MFA.
+        secondary_auth_initiated:
+          type: string
+          description: >
+            If null, indicates that no secondary authentication has been initiated. If equal to "sms_otp", indicates
+            that the Member has a phone number, and a one time passcode has been sent to the Member's phone number.
+            No secondary authentication will be initiated during calls to the discovery authenticate or list
+            organizations endpoints, even if the Member has a phone number.
 
     MicrosoftOAuthFactor:
       type: object
@@ -1131,6 +1158,21 @@ components:
       required:
         - phone_id
         - phone_number
+
+    PrimaryRequired:
+      type: object
+      properties:
+        allowed_auth_methods:
+          type: array
+          items:
+            type: string
+          description: >
+            Details the auth method that the member must also complete to fulfill the primary authentication
+            requirements of the Organization. For example, a value of `[magic_link]` indicates that the Member must
+            also complete a magic link authentication step. If you have an intermediate session token, you must pass
+            it into that primary authentication step.
+      required:
+        - allowed_auth_methods
 
     RecoveryCodeFactor:
       type: object
@@ -2499,6 +2541,85 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  member_id:
+                    type: string
+                    description: Globally unique UUID that identifies a specific Member.
+                  method_id:
+                    type: string
+                    description: The email or device involved in the authentication.
+                  reset_sessions:
+                    type: boolean
+                    description: This field is deprecated.
+                  organization_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that identifies a specific Organization. The `organization_id` is critical to
+                      perform operations on an Organization, so be sure to preserve this value.
+                  member:
+                    $ref: "#/components/schemas/Member"
+                    description: The [Member object](https://stytch.com/docs/b2b/api/member-object)
+                  session_token:
+                    type: string
+                    description: A secret token for a given Stytch Session.
+                  session_jwt:
+                    type: string
+                    description: The JSON Web Token (JWT) for a given Stytch Session.
+                  organization:
+                    $ref: "#/components/schemas/Organization"
+                    description: The [Organization object](https://stytch.com/docs/b2b/api/organization-object).
+                  intermediate_session_token:
+                    type: string
+                    description: >
+                      The returned Intermediate Session Token contains an Email Magic Link factor associated with the Member's
+                      email address. If this value is non-empty, the member must complete an MFA step to finish logging in to
+                      the Organization. The token can be used with the
+                      [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+                      [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+                      [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an
+                      MFA flow and log in to the Organization. The token has a default expiry of 10 minutes. It can also be
+                      used with the
+                      [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session)
+                      to join a specific Organization that allows the factors represented by the intermediate session token;
+                      or the
+                      [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to create a new Organization and Member. Intermediate Session Tokens have a default expiry of 10 minutes.
+                  member_authenticated:
+                    type: boolean
+                    description: >
+                      Indicates whether the Member is fully authenticated. If false, the Member needs to complete an MFA step
+                      to log in to the Organization.
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  member_session:
+                    $ref: "#/components/schemas/MemberSession"
+                    description: The [Session object](https://stytch.com/docs/b2b/api/session-object).
+                  mfa_required:
+                    $ref: "#/components/schemas/MfaRequired"
+                    description: Information about the MFA requirements of the Organization and the Member's options for fulfilling MFA.
+                  primary_required:
+                    $ref: "#/components/schemas/PrimaryRequired"
+                    description: Information about the primary authentication requirements of the Organization.
+                required:
+                  - request_id
+                  - member_id
+                  - method_id
+                  - reset_sessions
+                  - organization_id
+                  - member
+                  - session_token
+                  - session_jwt
+                  - organization
+                  - intermediate_session_token
+                  - member_authenticated
+                  - status_code
         default:
           description: Error response
           content:

--- a/vendor/stytch-openapi.yml
+++ b/vendor/stytch-openapi.yml
@@ -3588,6 +3588,93 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  intermediate_session_token:
+                    type: string
+                    description: >
+                      The Intermediate Session Token. This token does not necessarily belong to a specific instance of a
+                      Member, but represents a bag of factors that may be converted to a member session. The token can be used
+                      with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+                      [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+                      [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an
+                      MFA flow and log in to the Organization. The token has a default expiry of 10 minutes. It can also be
+                      used with the
+                      [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session)
+                      to join a specific Organization that allows the factors represented by the intermediate session token;
+                      or the
+                      [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to create a new Organization and Member. Intermediate Session Tokens have a default expiry of 10 minutes.
+                  email_address:
+                    type: string
+                    description: The email address.
+                  discovered_organizations:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DiscoveredOrganization"
+                    description: >
+                      An array of `discovered_organization` objects tied to the `intermediate_session_token`, `session_token`,
+                      or `session_jwt`. See the
+                      [Discovered Organization Object](https://stytch.com/docs/b2b/api/discovered-organization-object) for
+                      complete details.
+
+                        Note that Organizations will only appear here under any of the following conditions:
+                        1. The end user is already a Member of the Organization.
+                        2. The end user is invited to the Organization.
+                        3. The end user can join the Organization because:
+
+                            a) The Organization allows JIT provisioning.
+
+                            b) The Organizations' allowed domains list contains the Member's email domain.
+
+                            c) The Organization has at least one other Member with a verified email address with the same
+                      domain as the end user (to prevent phishing attacks).
+                  provider_type:
+                    type: string
+                    description: >
+                      Denotes the OAuth identity provider that the user has authenticated with, e.g. Google, Microsoft, GitHub
+                      etc.
+                  provider_tenant_id:
+                    type: string
+                    description: >
+                      The tenant ID returned by the OAuth provider. This is typically used to identify an organization or
+                      group within the provider's domain. For example, in HubSpot this is a Hub ID, in Slack this is the
+                      Workspace ID, and in GitHub this is an organization ID. This field will only be populated if exactly one
+                      tenant ID is returned from a successful OAuth authentication and developers should prefer
+                      `provider_tenant_ids` over this since it accounts for the possibility of an OAuth provider yielding
+                      multiple tenant IDs.
+                  provider_tenant_ids:
+                    type: array
+                    items:
+                      type: string
+                    description: >
+                      All tenant IDs returned by the OAuth provider. These is typically used to identify organizations or
+                      groups within the provider's domain. For example, in HubSpot this is a Hub ID, in Slack this is the
+                      Workspace ID, and in GitHub this is an organization ID. Some OAuth providers do not return tenant IDs,
+                      some providers are guaranteed to return one, and some may return multiple. This field will always be
+                      populated if at least one tenant ID was returned from the OAuth provider and developers should prefer
+                      this field over `provider_tenant_id`.
+                  full_name:
+                    type: string
+                    description: The full name of the authenticated end user, if available.
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                required:
+                  - request_id
+                  - intermediate_session_token
+                  - email_address
+                  - discovered_organizations
+                  - provider_type
+                  - provider_tenant_id
+                  - provider_tenant_ids
+                  - full_name
+                  - status_code
         default:
           description: Error response
           content:

--- a/vendor/stytch-openapi.yml
+++ b/vendor/stytch-openapi.yml
@@ -294,6 +294,30 @@ components:
         - id
         - provider_subject
 
+    DiscoveredOrganization:
+      type: object
+      properties:
+        member_authenticated:
+          type: boolean
+          description: >
+            Indicates whether the Member has all of the factors needed to fully authenticate to this Organization.
+            If false, the Member may need to complete an MFA step or complete a different primary authentication
+            flow. See the `primary_required` and `mfa_required` fields for more details on each.
+        organization:
+          $ref: "#/components/schemas/Organization"
+          description: The [Organization object](https://stytch.com/docs/b2b/api/organization-object).
+        membership:
+          $ref: "#/components/schemas/Membership"
+          description: Information about the membership.
+        primary_required:
+          $ref: "#/components/schemas/PrimaryRequired"
+          description: Information about the primary authentication requirements of the Organization.
+        mfa_required:
+          $ref: "#/components/schemas/MfaRequired"
+          description: Information about the MFA requirements of the Organization and the Member's options for fulfilling MFA.
+      required:
+        - member_authenticated
+
     EmailFactor:
       type: object
       properties:
@@ -655,6 +679,26 @@ components:
         - mfa_phone_number
         - default_mfa_method
         - roles
+
+    Membership:
+      type: object
+      properties:
+        type:
+          type: string
+          description: >
+            Either `active_member`, `pending_member`, `invited_member`, `eligible_to_join_by_email_domain`, or
+            `eligible_to_join_by_oauth_tenant`
+        details:
+          type: object
+          additionalProperties: true
+          description: An object containing additional metadata about the membership, if available.
+        member:
+          $ref: "#/components/schemas/Member"
+          description: >
+            The [Member object](https://stytch.com/docs/b2b/api/member-object) if one already exists, or null if one
+            does not.
+      required:
+        - type
 
     MemberOptions:
       type: object
@@ -2696,6 +2740,61 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  intermediate_session_token:
+                    type: string
+                    description: >
+                      The Intermediate Session Token. This token does not necessarily belong to a specific instance of a
+                      Member, but represents a bag of factors that may be converted to a member session. The token can be used
+                      with the [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+                      [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+                      [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an
+                      MFA flow and log in to the Organization. The token has a default expiry of 10 minutes. It can also be
+                      used with the
+                      [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session)
+                      to join a specific Organization that allows the factors represented by the intermediate session token;
+                      or the
+                      [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to create a new Organization and Member. Intermediate Session Tokens have a default expiry of 10 minutes.
+                  email_address:
+                    type: string
+                    description: The email address.
+                  discovered_organizations:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/DiscoveredOrganization"
+                    description: >
+                      An array of `discovered_organization` objects tied to the `intermediate_session_token`, `session_token`,
+                      or `session_jwt`. See the
+                      [Discovered Organization Object](https://stytch.com/docs/b2b/api/discovered-organization-object) for
+                      complete details.
+
+                        Note that Organizations will only appear here under any of the following conditions:
+                        1. The end user is already a Member of the Organization.
+                        2. The end user is invited to the Organization.
+                        3. The end user can join the Organization because:
+
+                            a) The Organization allows JIT provisioning.
+
+                            b) The Organizations' allowed domains list contains the Member's email domain.
+
+                            c) The Organization has at least one other Member with a verified email address with the same
+                      domain as the end user (to prevent phishing attacks).
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                required:
+                  - request_id
+                  - intermediate_session_token
+                  - email_address
+                  - discovered_organizations
+                  - status_code
         default:
           description: Error response
           content:

--- a/vendor/stytch-openapi.yml
+++ b/vendor/stytch-openapi.yml
@@ -3240,6 +3240,129 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  member_id:
+                    type: string
+                    description: Globally unique UUID that identifies a specific Member.
+                  provider_subject:
+                    type: string
+                    description: >
+                      The unique identifier for the User within a given OAuth provider. Also commonly called the `sub` or
+                      "Subject field" in OAuth protocols.
+                  provider_type:
+                    type: string
+                    description: >
+                      Denotes the OAuth identity provider that the user has authenticated with, e.g. Google, Microsoft, GitHub
+                      etc.
+                  session_token:
+                    type: string
+                    description: A secret token for a given Stytch Session.
+                  session_jwt:
+                    type: string
+                    description: The JSON Web Token (JWT) for a given Stytch Session.
+                  member:
+                    $ref: "#/components/schemas/Member"
+                    description: The [Member object](https://stytch.com/docs/b2b/api/member-object)
+                  organization_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that identifies a specific Organization. The `organization_id` is critical to
+                      perform operations on an Organization, so be sure to preserve this value.
+                  organization:
+                    $ref: "#/components/schemas/Organization"
+                    description: The [Organization object](https://stytch.com/docs/b2b/api/organization-object).
+                  reset_sessions:
+                    type: boolean
+                    description: This field is deprecated.
+                  member_authenticated:
+                    type: boolean
+                    description: >
+                      Indicates whether the Member is fully authenticated. If false, the Member needs to complete an MFA step
+                      to log in to the Organization.
+                  intermediate_session_token:
+                    type: string
+                    description: >
+                      The returned Intermediate Session Token contains an OAuth factor associated with the Member's email
+                      address. If this value is non-empty, the member must complete an MFA step to finish logging in to the
+                      Organization. The token can be used with the
+                      [OTP SMS Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-otp-sms),
+                      [TOTP Authenticate endpoint](https://stytch.com/docs/b2b/api/authenticate-totp), or
+                      [Recovery Codes Recover endpoint](https://stytch.com/docs/b2b/api/recovery-codes-recover) to complete an
+                      MFA flow and log in to the Organization. The token has a default expiry of 10 minutes. It can also be
+                      used with the
+                      [Exchange Intermediate Session endpoint](https://stytch.com/docs/b2b/api/exchange-intermediate-session)
+                      to join a specific Organization that allows the factors represented by the intermediate session token;
+                      or the
+                      [Create Organization via Discovery endpoint](https://stytch.com/docs/b2b/api/create-organization-via-discovery) to create a new Organization and Member. Intermediate Session Tokens have a default expiry of 10 minutes.
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  member_session:
+                    $ref: "#/components/schemas/MemberSession"
+                    description: The [Session object](https://stytch.com/docs/b2b/api/session-object).
+                  provider_values:
+                    type: object
+                    properties:
+                      scopes:
+                        type: array
+                        items:
+                          type: string
+                        description: >
+                          The OAuth scopes included for a given provider. See each provider's section above to see which scopes
+                          are included by default and how to add custom scopes.
+                      access_token:
+                        type: string
+                        description: >
+                          The `access_token` that you may use to access the User's data in the provider's API.
+                      refresh_token:
+                        type: string
+                        description: >
+                          The `refresh_token` that you may use to obtain a new `access_token` for the User within the provider's
+                          API.
+                      expires_at:
+                        type: string
+                        description: The expiration time of the access token.
+                      id_token:
+                        type: string
+                        description: >
+                          The `id_token` returned by the OAuth provider. ID Tokens are JWTs that contain structured information
+                          about a user. The exact content of each ID Token varies from provider to provider. ID Tokens are
+                          returned from OAuth providers that conform to the [OpenID Connect](https://openid.net/foundation/)
+                          specification, which is based on OAuth.
+                    description: >
+                      The `provider_values` object lists relevant identifiers, values, and scopes for a given OAuth provider.
+                      For example this object will include a provider's `access_token` that you can use to access the
+                      provider's API for a given user.
+
+                        Note that these values will vary based on the OAuth provider in question, e.g. `id_token` is only
+                      returned by Microsoft. Google One Tap does not return access tokens or refresh tokens.
+                  mfa_required:
+                    $ref: "#/components/schemas/MfaRequired"
+                    description: Information about the MFA requirements of the Organization and the Member's options for fulfilling MFA.
+                  primary_required:
+                    $ref: "#/components/schemas/PrimaryRequired"
+                    description: Information about the primary authentication requirements of the Organization.
+                required:
+                  - request_id
+                  - member_id
+                  - provider_subject
+                  - provider_type
+                  - session_token
+                  - session_jwt
+                  - member
+                  - organization_id
+                  - organization
+                  - reset_sessions
+                  - member_authenticated
+                  - intermediate_session_token
+                  - status_code
         default:
           description: Error response
           content:

--- a/vendor/stytch-openapi.yml
+++ b/vendor/stytch-openapi.yml
@@ -2377,6 +2377,38 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  member_id:
+                    type: string
+                    description: Globally unique UUID that identifies a specific Member.
+                  member_created:
+                    type: boolean
+                    description: >
+                      A flag indicating true if a new Member object was created and false if the Member object already
+                      existed.
+                  member:
+                    $ref: "#/components/schemas/Member"
+                    description: The Member object
+                  organization:
+                    $ref: "#/components/schemas/Organization"
+                    description: The Organization object
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                required:
+                  - request_id
+                  - member_id
+                  - member_created
+                  - member
+                  - organization
+                  - status_code
         default:
           description: Error response
           content:
@@ -2409,6 +2441,32 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  member_id:
+                    type: string
+                    description: Globally unique UUID that identifies a specific Member.
+                  member:
+                    $ref: "#/components/schemas/Member"
+                    description: The Member object
+                  organization:
+                    $ref: "#/components/schemas/Organization"
+                    description: The Organization object
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                required:
+                  - request_id
+                  - member_id
+                  - member
+                  - organization
+                  - status_code
         default:
           description: Error response
           content:

--- a/vendor/stytch-openapi.yml
+++ b/vendor/stytch-openapi.yml
@@ -3384,12 +3384,26 @@ paths:
             type: string
           example: "{{PUBLIC_TOKEN}}"
       responses:
-        "200":
+        "302":
           description: Successful response
           content:
             application/json:
               schema:
                 type: object
+                properties:
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  redirect_url:
+                    type: string
+                    description: The url to redirect to. This should be done automatically by the browser.
         default:
           description: Error response
           content:
@@ -3411,12 +3425,143 @@ paths:
             type: string
           example: "{{PUBLIC_TOKEN}}"
       responses:
-        "200":
+        "302":
           description: Successful response
           content:
             application/json:
               schema:
                 type: object
+                properties:
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  redirect_url:
+                    type: string
+                    description: The url to redirect to. This should be done automatically by the browser.
+  /v1/b2b/public/oauth/hubspot/discovery/start:
+    get:
+      operationId: oauth/discovery_hubspot
+      tags:
+        - oauth
+      summary: Use HubSpot for discovery
+      security:
+        - noauthAuth: []
+      parameters:
+        - name: public_token
+          in: query
+          schema:
+            type: string
+          example: "{{PUBLIC_TOKEN}}"
+      responses:
+        "307":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  redirect_url:
+                    type: string
+                    description: The url to redirect to. This should be done automatically by the browser.
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /v1/b2b/public/oauth/slack/discovery/start:
+    get:
+      operationId: oauth/discovery_slack
+      tags:
+        - oauth
+      summary: Use Slack for discovery
+      security:
+        - noauthAuth: []
+      parameters:
+        - name: public_token
+          in: query
+          schema:
+            type: string
+          example: "{{PUBLIC_TOKEN}}"
+      responses:
+        "307":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  redirect_url:
+                    type: string
+                    description: The url to redirect to. This should be done automatically by the browser.
+        default:
+          description: Error response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
+  /v1/b2b/public/oauth/github/discovery/start:
+    get:
+      operationId: oauth/discovery_github
+      tags:
+        - oauth
+      summary: Use GitHub for discovery
+      security:
+        - noauthAuth: []
+      parameters:
+        - name: public_token
+          in: query
+          schema:
+            type: string
+          example: "{{PUBLIC_TOKEN}}"
+      responses:
+        "307":
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  redirect_url:
+                    type: string
+                    description: The url to redirect to. This should be done automatically by the browser.
         default:
           description: Error response
           content:

--- a/vendor/stytch-openapi.yml
+++ b/vendor/stytch-openapi.yml
@@ -1218,6 +1218,195 @@ components:
       required:
         - allowed_auth_methods
 
+    RBACPolicy:
+      type: object
+      properties:
+        roles:
+          type: array
+          items:
+            $ref: "#/components/schemas/RBACPolicyRole"
+          description: An array of [Role objects](https://stytch.com/docs/b2b/api/rbac-role-object).
+        resources:
+          type: array
+          items:
+            $ref: "#/components/schemas/RBACPolicyResource"
+          description: An array of [Resource objects](https://stytch.com/docs/b2b/api/rbac-resource-object).
+        scopes:
+          type: array
+          items:
+            $ref: "#/components/schemas/RBACPolicyScope"
+      required:
+        - roles
+        - resources
+        - scopes
+
+    RBACPolicyResource:
+      type: object
+      properties:
+        resource_id:
+          type: string
+          description: >
+            A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
+
+            A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch
+            default Resources with reserved  `resource_id`s. These include:
+
+            * `stytch.organization`
+            * `stytch.member`
+            * `stytch.sso`
+            * `stytch.self`
+
+            Check out the
+            [guide on Stytch default Resources](https://stytch.com/docs/b2b/guides/rbac/stytch-default) for a more
+            detailed explanation.
+        description:
+          type: string
+          description: The description of the RBAC Resource.
+        actions:
+          type: array
+          items:
+            type: string
+          description: >
+            A list of all possible actions for a provided Resource.
+
+            Reserved `actions` that are predefined by Stytch include:
+
+            * `*`
+            * For the `stytch.organization` Resource:
+              * `update.info.name`
+              * `update.info.slug`
+              * `update.info.untrusted_metadata`
+              * `update.info.email_jit_provisioning`
+              * `update.info.logo_url`
+              * `update.info.email_invites`
+              * `update.info.allowed_domains`
+              * `update.info.default_sso_connection`
+              * `update.info.sso_jit_provisioning`
+              * `update.info.mfa_policy`
+              * `update.info.implicit_roles`
+              * `delete`
+            * For the `stytch.member` Resource:
+              * `create`
+              * `update.info.name`
+              * `update.info.untrusted_metadata`
+              * `update.info.mfa-phone`
+              * `update.info.delete.mfa-phone`
+              * `update.settings.is-breakglass`
+              * `update.settings.mfa_enrolled`
+              * `update.settings.roles`
+              * `search`
+              * `delete`
+            * For the `stytch.sso` Resource:
+              * `create`
+              * `update`
+              * `delete`
+            * For the `stytch.self` Resource:
+              * `update.info.name`
+              * `update.info.untrusted_metadata`
+              * `update.info.mfa-phone`
+              * `update.info.delete.mfa-phone`
+              * `update.info.delete.password`
+              * `update.settings.mfa_enrolled`
+              * `delete`
+      required:
+        - resource_id
+        - description
+        - actions
+
+    RBACPolicyRole:
+      type: object
+      properties:
+        role_id:
+          type: string
+          description: >
+            The unique identifier of the RBAC Role, provided by the developer and intended to be human-readable.
+
+            Reserved `role_id`s that are predefined by Stytch include:
+
+            * `stytch_member`
+            * `stytch_admin`
+
+            Check out the [guide on Stytch default Roles](https://stytch.com/docs/b2b/guides/rbac/stytch-default)
+            for a more detailed explanation.
+        description:
+          type: string
+          description: The description of the RBAC Role.
+        permissions:
+          type: array
+          items:
+            $ref: "#/components/schemas/RBACPolicyRolePermission"
+          description: >
+            A list of permissions that link a [Resource](https://stytch.com/docs/b2b/api/rbac-resource-object) to a
+            list of actions.
+      required:
+        - role_id
+        - description
+        - permissions
+
+    RBACPolicyRolePermission:
+      type: object
+      properties:
+        resource_id:
+          type: string
+          description: >
+            A unique identifier of the RBAC Resource, provided by the developer and intended to be human-readable.
+
+            A `resource_id` is not allowed to start with `stytch`, which is a special prefix used for Stytch
+            default Resources with reserved  `resource_id`s. These include:
+
+            * `stytch.organization`
+            * `stytch.member`
+            * `stytch.sso`
+            * `stytch.self`
+
+            Check out the
+            [guide on Stytch default Resources](https://stytch.com/docs/docs/b2b/guides/rbac/stytch-default) for a
+            more detailed explanation.
+        actions:
+          type: array
+          items:
+            type: string
+          description: >
+            A list of permitted actions the Scope is required to take with the provided Resource. You can use `*` as
+            a wildcard to require a Scope permission to use all possible actions related to the Resource.
+      required:
+        - resource_id
+        - actions
+
+    RBACPolicyScope:
+      type: object
+      properties:
+        scope:
+          type: string
+          description: The scope identifier.
+        description:
+          type: string
+          description: The description of the scope.
+        permissions:
+          type: array
+          items:
+            $ref: "#/components/schemas/RBACPolicyScopePermission"
+          description: The permissions associated with this scope.
+      required:
+        - scope
+        - description
+        - permissions
+
+    RBACPolicyScopePermission:
+      type: object
+      properties:
+        resource_id:
+          type: string
+          description: The ID of the resource this permission applies to.
+        actions:
+          type: array
+          items:
+            type: string
+          description: The actions allowed for this resource.
+      required:
+        - resource_id
+        - actions
+
     RecoveryCodeFactor:
       type: object
       properties:
@@ -2431,6 +2620,26 @@ paths:
             application/json:
               schema:
                 type: object
+                properties:
+                  request_id:
+                    type: string
+                    description: >
+                      Globally unique UUID that is returned with every API call. This value is important to log for debugging
+                      purposes; we may ask for this value to help identify a specific API call when helping you debug an issue.
+                  status_code:
+                    type: integer
+                    description: >
+                      The HTTP status code of the response. Stytch follows standard HTTP response status code patterns, e.g.
+                      2XX values equate to success, 3XX values are redirects, 4XX are client errors, and 5XX are server errors.
+                  policy:
+                    $ref: "#/components/schemas/RBACPolicy"
+                    description: >
+                      The RBAC Policy document that contains all defined Roles and Resources – which are managed in the
+                      [Dashboard](https://stytch.com/docs/dashboard/rbac). Read more about these entities and how they work in
+                      our [RBAC overview](https://stytch.com/docs/b2b/guides/rbac/overview).
+                required:
+                  - request_id
+                  - status_code
         default:
           description: Error response
           content:


### PR DESCRIPTION
Many of the endpoints in the OpenAPI description have untyped responses. This PR adds types for some of the magic link-related endpoints.